### PR TITLE
Fuzz test: adding `let _ = () in ...` to subexprs shouldn't change compilability

### DIFF
--- a/compiler-fuzz-test/README.md
+++ b/compiler-fuzz-test/README.md
@@ -1,0 +1,2 @@
+`elm-test` will always fail.
+`elm-test --compiler=./patching-elm-compiler.js` should pass and call elm make.

--- a/compiler-fuzz-test/elm.json
+++ b/compiler-fuzz-test/elm.json
@@ -1,0 +1,35 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src",
+        "../src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.1",
+            "miniBill/elm-unicode": "1.1.1",
+            "stil4m/elm-syntax": "7.3.9"
+        },
+        "indirect": {
+            "elm/json": "1.1.4",
+            "elm/parser": "1.1.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.5",
+            "rtfeldman/elm-hex": "1.0.0",
+            "stil4m/structured-writer": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "2.2.1"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/random": "1.0.0"
+        }
+    }
+}

--- a/compiler-fuzz-test/patching-elm-compiler.js
+++ b/compiler-fuzz-test/patching-elm-compiler.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+function findOutputPath(args) {
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--output' && typeof args[i + 1] === 'string') {
+            return args[i + 1];
+        }
+    }
+    throw new Error("elm-test didn't use --output flag, it seems: " + args.join(' '));
+}
+
+const args = process.argv.slice(2);
+const outputPath = findOutputPath(args);
+
+const result = spawnSync('elm', args, { stdio: 'inherit' });
+
+if (result.status !== 0) {
+    process.exit(result.status);
+}
+
+const outputDir = path.dirname(outputPath);
+const projectDir = path.join(outputDir, 'elm-stuff', 'elm-make-compiles');
+const srcDir = path.join(projectDir, 'src');
+const elmJsonPath = path.join(projectDir, 'elm.json');
+const modulePath = path.join(srcDir, 'FuzzedModule.elm');
+
+try {
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.mkdirSync(srcDir, { recursive: true });
+} catch (e) { }
+
+const elmJson = {
+    "type": "package",
+    "name": "test/fuzzed-module",
+    "summary": "Fuzzed module for testing compilation",
+    "license": "BSD-3-Clause",
+    "version": "1.0.0",
+    "exposed-modules": ["FuzzedModule"],
+    "elm-version": "0.19.0 <= v < 0.20.0",
+    "dependencies": {
+        "elm/core": "1.0.2 <= v < 2.0.0"
+    },
+    "test-dependencies": {}
+};
+fs.writeFileSync(elmJsonPath, JSON.stringify(elmJson, null, 4));
+
+const absoluteProjectDir = path.resolve(projectDir);
+const absoluteModulePath = path.resolve(modulePath);
+
+const jsContent = fs.readFileSync(outputPath, 'utf8');
+
+const escapedProjectDir = JSON.stringify(absoluteProjectDir);
+const escapedModulePath = JSON.stringify(absoluteModulePath);
+
+const functionPattern = /var \$author\$project\$ElmMake\$compiles = function \(elmSourceCode\) \{[^}]*return false;[^}]*\};/s;
+const replacementFunction = `
+// patching-elm-compiler.js START
+var fs = require('node:fs');
+
+// Hash function: https://stackoverflow.com/a/52171480
+const TSH = s => { for(var i=0,h=9;i<s.length;)h=Math.imul(h^s.charCodeAt(i++),9**9);return h^h>>>9; };
+
+// Memoize ElmMake.compiles
+globalThis.__elmMakeCompilesMemo__ = new Map();
+
+// Pre-computed paths (set up by patching-elm-compiler.js)
+var $author$project$ElmMake$compiles$projectDir = ${escapedProjectDir};
+var $author$project$ElmMake$compiles$modulePath = ${escapedModulePath};
+
+var $author$project$ElmMake$compiles = function (elmSourceCode) {
+    var { spawnSync } = require('node:child_process');
+
+    var hash = TSH(elmSourceCode);
+    var memo = globalThis.__elmMakeCompilesMemo__;
+    if (memo.has(hash)) {
+        return memo.get(hash);
+    }
+
+    console.log(elmSourceCode.slice(44,64).replace(/\\n/g, ' ').trim()+' ...');
+    
+    fs.writeFileSync($author$project$ElmMake$compiles$modulePath, elmSourceCode);
+    
+    var makeResult = spawnSync('elm', ['make', 'src/FuzzedModule.elm'], {
+        cwd: $author$project$ElmMake$compiles$projectDir,
+        stdio: 'pipe'
+    });
+
+    var result = makeResult.status === 0;
+    if (!result) {
+        console.log("elm make failed for source:");
+        console.log(elmSourceCode);
+        console.log('elm make error:');
+        console.log(makeResult.stderr ? makeResult.stderr.toString() : '(no stderr)');
+    }
+    memo.set(hash, result);
+    return result;
+};
+
+// patching-elm-compiler.js END
+`;
+
+const patchedContent = jsContent.replace(functionPattern, replacementFunction);
+
+if (patchedContent === jsContent) {
+    throw new Error('Warning: Could not find the compiles function to patch');
+}
+
+fs.writeFileSync(outputPath, patchedContent, 'utf8');
+console.log(`Patched ${outputPath} successfully`);

--- a/compiler-fuzz-test/src/ElmMake.elm
+++ b/compiler-fuzz-test/src/ElmMake.elm
@@ -1,0 +1,17 @@
+module ElmMake exposing (compiles)
+
+{-| A huge hack.
+-}
+
+
+{-| As is, this does not work (gives false negatives).
+
+Will be patched after compilation by the wrapped-elm-compiler.js to actually
+shell out to `elm make` with a dummy project containing this source code.
+
+That way we can use `elm-test` fuzz testing machinery!
+
+-}
+compiles : String -> Bool
+compiles elmSourceCode =
+    False

--- a/compiler-fuzz-test/src/Instrument.elm
+++ b/compiler-fuzz-test/src/Instrument.elm
@@ -1,0 +1,425 @@
+module Instrument exposing (instrument)
+
+import Elm.Syntax.Declaration exposing (Declaration)
+import Elm.Syntax.Expression exposing (Expression)
+import Elm.Syntax.File exposing (File)
+import Elm.Syntax.Node exposing (Node(..))
+import Elm.Syntax.Pattern exposing (Pattern)
+import Elm.Syntax.Range exposing (Range)
+
+
+instrument : File -> File
+instrument file =
+    { file | declarations = List.map instrumentDecl file.declarations }
+
+
+{-|
+
+     expr
+     -->
+     let _ = () in expr
+
+-}
+wrapExpr : Range -> Node Elm.Syntax.Expression.Expression -> Node Elm.Syntax.Expression.Expression
+wrapExpr exprRange exprNode =
+    let
+        nodify : a -> Node a
+        nodify a =
+            Node exprRange a
+    in
+    nodify <|
+        Elm.Syntax.Expression.LetExpression
+            { declarations =
+                [ nodify <|
+                    Elm.Syntax.Expression.LetDestructuring
+                        (nodify Elm.Syntax.Pattern.AllPattern)
+                        (nodify Elm.Syntax.Expression.UnitExpr)
+                ]
+            , expression = exprNode
+            }
+
+
+instrumentDecl : Node Declaration -> Node Declaration
+instrumentDecl declNode =
+    let
+        declRange : Range
+        declRange =
+            Elm.Syntax.Node.range declNode
+    in
+    case Elm.Syntax.Node.value declNode of
+        Elm.Syntax.Declaration.FunctionDeclaration fn ->
+            instrumentFnDecl fn declRange
+
+        Elm.Syntax.Declaration.AliasDeclaration typeAlias ->
+            declNode
+
+        Elm.Syntax.Declaration.CustomTypeDeclaration type_ ->
+            declNode
+
+        Elm.Syntax.Declaration.PortDeclaration _ ->
+            declNode
+
+        Elm.Syntax.Declaration.InfixDeclaration _ ->
+            declNode
+
+        Elm.Syntax.Declaration.Destructuring patternNode exprNode ->
+            instrumentDestructuringDecl patternNode exprNode declRange
+
+
+instrumentFnDecl : Elm.Syntax.Expression.Function -> Range -> Node Declaration
+instrumentFnDecl fn declRange =
+    let
+        fnImpl : Elm.Syntax.Expression.FunctionImplementation
+        fnImpl =
+            Elm.Syntax.Node.value fn.declaration
+
+        declarationName : String
+        declarationName =
+            Elm.Syntax.Node.value fnImpl.name
+
+        instrumentedExpr =
+            instrumentExprWithCategory fnImpl.expression declarationName
+
+        newFnImpl : Elm.Syntax.Expression.FunctionImplementation
+        newFnImpl =
+            { fnImpl | expression = instrumentedExpr }
+
+        newFn : Elm.Syntax.Expression.Function
+        newFn =
+            { fn | declaration = Elm.Syntax.Node.map (always newFnImpl) fn.declaration }
+    in
+    Node declRange (Elm.Syntax.Declaration.FunctionDeclaration newFn)
+
+
+instrumentDestructuringDecl : Node Pattern -> Node Expression -> Range -> Node Declaration
+instrumentDestructuringDecl patternNode exprNode declRange =
+    let
+        instrumentedExpr =
+            instrumentExprWithCategory exprNode "_destructuring"
+    in
+    Node declRange (Elm.Syntax.Declaration.Destructuring patternNode instrumentedExpr)
+
+
+instrumentExpr : Node Elm.Syntax.Expression.Expression -> String -> Node Elm.Syntax.Expression.Expression
+instrumentExpr exprNode declarationName =
+    instrumentExprRecurse exprNode declarationName
+
+
+instrumentExprWithCategory : Node Elm.Syntax.Expression.Expression -> String -> Node Elm.Syntax.Expression.Expression
+instrumentExprWithCategory exprNode declarationName =
+    let
+        exprRange : Range
+        exprRange =
+            Elm.Syntax.Node.range exprNode
+    in
+    case Elm.Syntax.Node.value exprNode of
+        Elm.Syntax.Expression.IfBlock condition thenBranch elseBranch ->
+            let
+                instCondition =
+                    instrumentExpr condition declarationName
+
+                instThen =
+                    instrumentExprWithCategory thenBranch declarationName
+
+                instElse =
+                    instrumentExprWithCategory elseBranch declarationName
+            in
+            Node exprRange (Elm.Syntax.Expression.IfBlock instCondition instThen instElse)
+
+        Elm.Syntax.Expression.CaseExpression caseBlock ->
+            let
+                instExpr =
+                    instrumentExprWithCategory caseBlock.expression declarationName
+
+                instrumentedCases =
+                    List.map
+                        (\( pattern, caseExpr ) ->
+                            ( pattern, instrumentExprWithCategory caseExpr declarationName )
+                        )
+                        caseBlock.cases
+
+                newCaseBlock : Elm.Syntax.Expression.CaseBlock
+                newCaseBlock =
+                    { expression = instExpr
+                    , cases = instrumentedCases
+                    }
+            in
+            Node exprRange (Elm.Syntax.Expression.CaseExpression newCaseBlock)
+
+        _ ->
+            let
+                instrumentedInnerExpr =
+                    instrumentExprRecurse exprNode declarationName
+
+                wrappedExpr =
+                    wrapExpr exprRange instrumentedInnerExpr
+            in
+            wrappedExpr
+
+
+instrumentExprRecurse :
+    Node Elm.Syntax.Expression.Expression
+    -> String
+    -> Node Elm.Syntax.Expression.Expression
+instrumentExprRecurse exprNode declarationName =
+    let
+        exprRange : Range
+        exprRange =
+            Elm.Syntax.Node.range exprNode
+    in
+    case Elm.Syntax.Node.value exprNode of
+        Elm.Syntax.Expression.Application exprs ->
+            let
+                instrumentedExprs =
+                    instrumentExprList exprs declarationName
+            in
+            Node exprRange (Elm.Syntax.Expression.Application instrumentedExprs)
+
+        Elm.Syntax.Expression.OperatorApplication op dir left right ->
+            let
+                instLeft =
+                    if op == "&&" || op == "||" then
+                        instrumentExprWithCategory left declarationName
+
+                    else
+                        instrumentExpr left declarationName
+
+                instRight =
+                    if op == "&&" || op == "||" then
+                        instrumentExprWithCategory right declarationName
+
+                    else
+                        instrumentExpr right declarationName
+            in
+            Node exprRange (Elm.Syntax.Expression.OperatorApplication op dir instLeft instRight)
+
+        Elm.Syntax.Expression.IfBlock condition thenBranch elseBranch ->
+            let
+                instCondition =
+                    instrumentExpr condition declarationName
+
+                instThen =
+                    instrumentExprWithCategory thenBranch declarationName
+
+                instElse =
+                    instrumentExprWithCategory elseBranch declarationName
+            in
+            Node exprRange (Elm.Syntax.Expression.IfBlock instCondition instThen instElse)
+
+        Elm.Syntax.Expression.Negation inner ->
+            let
+                instInner =
+                    instrumentExpr inner declarationName
+            in
+            Node exprRange (Elm.Syntax.Expression.Negation instInner)
+
+        Elm.Syntax.Expression.TupledExpression exprs ->
+            let
+                instrumentedExprs =
+                    instrumentExprList exprs declarationName
+            in
+            Node exprRange (Elm.Syntax.Expression.TupledExpression instrumentedExprs)
+
+        Elm.Syntax.Expression.ParenthesizedExpression inner ->
+            let
+                instInner =
+                    instrumentExpr inner declarationName
+            in
+            Node exprRange (Elm.Syntax.Expression.ParenthesizedExpression instInner)
+
+        Elm.Syntax.Expression.LetExpression letBlock ->
+            let
+                instrumentedDecls =
+                    List.map
+                        (\declNode ->
+                            instrumentLetDeclaration declNode declarationName
+                        )
+                        letBlock.declarations
+
+                instLetExpr =
+                    instrumentExpr letBlock.expression declarationName
+
+                newLetBlock : Elm.Syntax.Expression.LetBlock
+                newLetBlock =
+                    { declarations = instrumentedDecls
+                    , expression = instLetExpr
+                    }
+            in
+            Node exprRange (Elm.Syntax.Expression.LetExpression newLetBlock)
+
+        Elm.Syntax.Expression.CaseExpression caseBlock ->
+            let
+                instExpr =
+                    instrumentExprWithCategory caseBlock.expression declarationName
+
+                instrumentedCases =
+                    List.map
+                        (\( pattern, caseExpr ) ->
+                            ( pattern, instrumentExprWithCategory caseExpr declarationName )
+                        )
+                        caseBlock.cases
+
+                newCaseBlock : Elm.Syntax.Expression.CaseBlock
+                newCaseBlock =
+                    { expression = instExpr
+                    , cases = instrumentedCases
+                    }
+            in
+            Node exprRange (Elm.Syntax.Expression.CaseExpression newCaseBlock)
+
+        Elm.Syntax.Expression.LambdaExpression lambda ->
+            let
+                instExpr =
+                    instrumentExpr lambda.expression declarationName
+
+                bodyRange : Range
+                bodyRange =
+                    Elm.Syntax.Node.range lambda.expression
+
+                wrappedBody =
+                    wrapExpr bodyRange instExpr
+
+                newLambda : Elm.Syntax.Expression.Lambda
+                newLambda =
+                    { lambda | expression = wrappedBody }
+            in
+            Node exprRange (Elm.Syntax.Expression.LambdaExpression newLambda)
+
+        Elm.Syntax.Expression.RecordExpr setters ->
+            let
+                instrumentedSetters =
+                    List.map
+                        (\setterNode ->
+                            let
+                                ( fieldNameNode, fieldExprNode ) =
+                                    Elm.Syntax.Node.value setterNode
+
+                                instExpr =
+                                    instrumentExpr fieldExprNode declarationName
+
+                                newSetter : Elm.Syntax.Expression.RecordSetter
+                                newSetter =
+                                    ( fieldNameNode, instExpr )
+                            in
+                            Node (Elm.Syntax.Node.range setterNode) newSetter
+                        )
+                        setters
+            in
+            Node exprRange (Elm.Syntax.Expression.RecordExpr instrumentedSetters)
+
+        Elm.Syntax.Expression.ListExpr exprs ->
+            let
+                instrumentedExprs =
+                    instrumentExprList exprs declarationName
+            in
+            Node exprRange (Elm.Syntax.Expression.ListExpr instrumentedExprs)
+
+        Elm.Syntax.Expression.RecordAccess record field ->
+            let
+                instRecord =
+                    instrumentExpr record declarationName
+            in
+            Node exprRange (Elm.Syntax.Expression.RecordAccess instRecord field)
+
+        Elm.Syntax.Expression.RecordUpdateExpression name setters ->
+            let
+                instrumentedSetters =
+                    List.map
+                        (\setterNode ->
+                            let
+                                ( fieldNameNode, fieldExprNode ) =
+                                    Elm.Syntax.Node.value setterNode
+
+                                instExpr =
+                                    instrumentExpr fieldExprNode declarationName
+
+                                newSetter : Elm.Syntax.Expression.RecordSetter
+                                newSetter =
+                                    ( fieldNameNode, instExpr )
+                            in
+                            Node (Elm.Syntax.Node.range setterNode) newSetter
+                        )
+                        setters
+            in
+            Node exprRange (Elm.Syntax.Expression.RecordUpdateExpression name instrumentedSetters)
+
+        Elm.Syntax.Expression.UnitExpr ->
+            exprNode
+
+        Elm.Syntax.Expression.FunctionOrValue _ _ ->
+            exprNode
+
+        Elm.Syntax.Expression.PrefixOperator _ ->
+            exprNode
+
+        Elm.Syntax.Expression.Operator _ ->
+            exprNode
+
+        Elm.Syntax.Expression.Integer _ ->
+            exprNode
+
+        Elm.Syntax.Expression.Hex _ ->
+            exprNode
+
+        Elm.Syntax.Expression.Floatable _ ->
+            exprNode
+
+        Elm.Syntax.Expression.Literal _ ->
+            exprNode
+
+        Elm.Syntax.Expression.CharLiteral _ ->
+            exprNode
+
+        Elm.Syntax.Expression.RecordAccessFunction _ ->
+            exprNode
+
+        Elm.Syntax.Expression.GLSLExpression _ ->
+            exprNode
+
+
+instrumentExprList : List (Node Elm.Syntax.Expression.Expression) -> String -> List (Node Elm.Syntax.Expression.Expression)
+instrumentExprList exprs declarationName =
+    List.map
+        (\exprNode_ ->
+            instrumentExpr exprNode_ declarationName
+        )
+        exprs
+
+
+instrumentLetDeclaration : Node Elm.Syntax.Expression.LetDeclaration -> String -> Node Elm.Syntax.Expression.LetDeclaration
+instrumentLetDeclaration declNode declarationName =
+    let
+        declRange : Range
+        declRange =
+            Elm.Syntax.Node.range declNode
+    in
+    case Elm.Syntax.Node.value declNode of
+        Elm.Syntax.Expression.LetFunction fn ->
+            let
+                fnImpl : Elm.Syntax.Expression.FunctionImplementation
+                fnImpl =
+                    Elm.Syntax.Node.value fn.declaration
+
+                instExpr =
+                    if List.isEmpty fnImpl.arguments then
+                        instrumentExpr fnImpl.expression declarationName
+
+                    else
+                        instrumentExprWithCategory fnImpl.expression declarationName
+
+                newFnImpl : Elm.Syntax.Expression.FunctionImplementation
+                newFnImpl =
+                    { fnImpl | expression = instExpr }
+
+                newFn : Elm.Syntax.Expression.Function
+                newFn =
+                    { fn | declaration = Elm.Syntax.Node.map (always newFnImpl) fn.declaration }
+            in
+            Node declRange (Elm.Syntax.Expression.LetFunction newFn)
+
+        Elm.Syntax.Expression.LetDestructuring pattern destrExpr ->
+            let
+                instDestrExpr =
+                    instrumentExpr destrExpr declarationName
+            in
+            Node declRange (Elm.Syntax.Expression.LetDestructuring pattern instDestrExpr)

--- a/compiler-fuzz-test/src/ListExtra.elm
+++ b/compiler-fuzz-test/src/ListExtra.elm
@@ -1,0 +1,24 @@
+module ListExtra exposing (uniqueBy)
+
+
+uniqueBy : (a -> b) -> List a -> List a
+uniqueBy f list =
+    uniqueHelp f [] list []
+
+
+uniqueHelp : (a -> b) -> List b -> List a -> List a -> List a
+uniqueHelp f existing remaining accumulator =
+    case remaining of
+        [] ->
+            List.reverse accumulator
+
+        first :: rest ->
+            let
+                computedFirst =
+                    f first
+            in
+            if List.member computedFirst existing then
+                uniqueHelp f existing rest accumulator
+
+            else
+                uniqueHelp f (computedFirst :: existing) rest (first :: accumulator)

--- a/compiler-fuzz-test/src/Main.elm
+++ b/compiler-fuzz-test/src/Main.elm
@@ -1,0 +1,12 @@
+module Main exposing (main)
+
+import ElmMake
+import Html
+
+
+main =
+    let
+        _ =
+            ElmMake.compiles ""
+    in
+    Html.text "compiles"

--- a/compiler-fuzz-test/tests/Tests.elm
+++ b/compiler-fuzz-test/tests/Tests.elm
@@ -1,0 +1,1048 @@
+module Tests exposing (suite)
+
+import Elm.Syntax.Declaration exposing (Declaration(..))
+import Elm.Syntax.Exposing exposing (Exposing(..), TopLevelExpose(..))
+import Elm.Syntax.Expression exposing (Expression(..), Function, FunctionImplementation)
+import Elm.Syntax.File exposing (File)
+import Elm.Syntax.Infix exposing (InfixDirection(..))
+import Elm.Syntax.Module exposing (DefaultModuleData, Module(..))
+import Elm.Syntax.Node exposing (Node(..))
+import Elm.Syntax.Pattern exposing (Pattern(..))
+import Elm.Syntax.Range exposing (Location, Range)
+import ElmMake
+import ElmSyntaxPrint
+import Expect
+import Fuzz exposing (Fuzzer)
+import Instrument
+import ListExtra
+import Set exposing (Set)
+import Test exposing (Test)
+import Test.Distribution
+
+
+toString : File -> String
+toString file =
+    file
+        |> ElmSyntaxPrint.module_
+        |> ElmSyntaxPrint.toString
+
+
+suite : Test
+suite =
+    Test.fuzzWith
+        { runs = 100000
+        , distribution =
+            Test.expectDistribution
+                [ ( Test.Distribution.atLeast 80, "original compiles", ElmMake.compiles << toString )
+                ]
+        }
+        fileFuzzer
+        "if a File compiles when stringified, it compiles when instrumented and stringified"
+    <|
+        \file ->
+            if ElmMake.compiles (toString file) then
+                file
+                    |> Instrument.instrument
+                    |> toString
+                    |> ElmMake.compiles
+                    |> Expect.equal True
+                    |> Expect.onFail "Compiled on its own but doesn't compile when instrumented"
+
+            else
+                -- We don't care about this input - it didn't compile on its own, so it likely won't compile when instrumented.
+                Expect.pass
+
+
+fileFuzzer : Fuzzer File
+fileFuzzer =
+    declarationFuzzer
+        |> Fuzz.map
+            (\declaration ->
+                { moduleDefinition =
+                    -- module FuzzedModule exposing (..)
+                    toNode
+                        (NormalModule
+                            { moduleName = toNode [ "FuzzedModule" ]
+                            , exposingList = toNode (All Elm.Syntax.Range.empty)
+                            }
+                        )
+                , imports = []
+                , declarations = [ declaration ]
+                , comments = []
+                }
+            )
+
+
+declarationFuzzer : Fuzzer (Node Declaration)
+declarationFuzzer =
+    functionFuzzer
+        |> Fuzz.map (\fn -> toNode (FunctionDeclaration fn))
+
+
+topLevelDeclarationName : String
+topLevelDeclarationName =
+    "x"
+
+
+functionFuzzer : Fuzzer Function
+functionFuzzer =
+    let
+        initialUsedNames =
+            Set.singleton topLevelDeclarationName
+    in
+    expressionFuzzer initialUsedNames 15
+        |> Fuzz.map
+            (\expr ->
+                { documentation = Nothing
+                , signature = Nothing
+                , declaration =
+                    toNode
+                        { name = toNode topLevelDeclarationName
+                        , arguments = []
+                        , expression = expr
+                        }
+                }
+            )
+
+
+expressionFuzzer : Set String -> Int -> Fuzzer (Node Expression)
+expressionFuzzer usedNames depth =
+    if depth <= 0 then
+        literalExpressionFuzzer
+
+    else
+        Fuzz.frequency
+            [ ( 1, literalExpressionFuzzer )
+            , ( 3, simpleOperationFuzzer usedNames depth )
+            , ( 1, unitExpressionFuzzer )
+            , ( 2, listExpressionFuzzer usedNames depth )
+            , ( 3, tupleExpressionFuzzer usedNames depth )
+            , ( 5, ifExpressionFuzzer usedNames depth )
+            , ( 6, caseExpressionFuzzer usedNames depth )
+            ]
+
+
+type ExprType
+    = -- TODO: functions? *gulp*
+      TInt
+    | TFloat
+    | TString
+    | TChar
+    | TBool
+    | TUnit
+
+
+exprTypeFuzzer : Fuzzer ExprType
+exprTypeFuzzer =
+    Fuzz.oneOfValues
+        [ TInt
+        , TFloat
+        , TString
+        , TChar
+        , TBool
+        , TUnit
+        ]
+
+
+exprTypeFuzzerWithoutFloat : Fuzzer ExprType
+exprTypeFuzzerWithoutFloat =
+    Fuzz.oneOfValues
+        [ TInt
+        , TString
+        , TChar
+        , TBool
+        , TUnit
+        ]
+
+
+boolToString : Bool -> String
+boolToString bool =
+    if bool then
+        "True"
+
+    else
+        "False"
+
+
+rawIntExprFuzzer : Fuzzer (Node Expression)
+rawIntExprFuzzer =
+    Fuzz.intRange -100 100 |> Fuzz.map (\i -> toNode (Integer i))
+
+
+rawFloatExprFuzzer : Fuzzer (Node Expression)
+rawFloatExprFuzzer =
+    Fuzz.floatRange -100.0 100.0 |> Fuzz.map (\f -> toNode (Floatable f))
+
+
+rawStringExprFuzzer : Fuzzer (Node Expression)
+rawStringExprFuzzer =
+    Fuzz.string |> Fuzz.map (String.slice 0 20) |> Fuzz.map (\s -> toNode (Literal s))
+
+
+rawCharExprFuzzer : Fuzzer (Node Expression)
+rawCharExprFuzzer =
+    charFuzzer |> Fuzz.map (\c -> toNode (CharLiteral c))
+
+
+rawBoolExprFuzzer : Fuzzer (Node Expression)
+rawBoolExprFuzzer =
+    Fuzz.bool |> Fuzz.map (\b -> toNode (FunctionOrValue [] (boolToString b)))
+
+
+expressionFuzzerOfType : Set String -> Int -> ExprType -> Fuzzer (Node Expression)
+expressionFuzzerOfType usedNames depth exprType =
+    if depth <= 0 then
+        case exprType of
+            TInt ->
+                rawIntExprFuzzer
+                    |> withOptionalNoOps
+
+            TFloat ->
+                rawFloatExprFuzzer
+                    |> withOptionalNoOps
+
+            TString ->
+                rawStringExprFuzzer
+                    |> withOptionalNoOps
+
+            TChar ->
+                rawCharExprFuzzer
+                    |> withOptionalNoOps
+
+            TBool ->
+                rawBoolExprFuzzer
+                    |> withOptionalNoOps
+
+            TUnit ->
+                Fuzz.constant (toNode UnitExpr)
+
+    else
+        withOptionalNoOps <|
+            case exprType of
+                TInt ->
+                    rawIntExprFuzzer
+
+                TFloat ->
+                    rawFloatExprFuzzer
+
+                TString ->
+                    rawStringExprFuzzer
+
+                TChar ->
+                    rawCharExprFuzzer
+
+                TBool ->
+                    Fuzz.lazy (\_ -> boolExpressionFuzzer usedNames depth)
+
+                TUnit ->
+                    Fuzz.constant (toNode UnitExpr)
+
+
+withOptionalNoOps : Fuzzer (Node Expression) -> Fuzzer (Node Expression)
+withOptionalNoOps baseFuzzer =
+    baseFuzzer
+        |> Fuzz.andThen
+            (\expr ->
+                Fuzz.frequency
+                    [ ( 7, Fuzz.constant expr )
+                    , ( 3, noOpWrap expr ) -- recurse!
+                    ]
+            )
+
+
+noOpWrap : Node Expression -> Fuzzer (Node Expression)
+noOpWrap expr =
+    Fuzz.oneOfValues
+        [ -- expr |> identity
+          toNode
+            (OperatorApplication "|>"
+                Right
+                (parenthesize expr)
+                (toNode (FunctionOrValue [] "identity"))
+            )
+        , -- identity <| expr
+          toNode
+            (OperatorApplication "<|"
+                Left
+                (toNode (FunctionOrValue [] "identity"))
+                (parenthesize expr)
+            )
+        , -- identity expr
+          toNode
+            (Application
+                [ toNode (FunctionOrValue [] "identity")
+                , expr
+                ]
+            )
+        , -- (expr)
+          parenthesize expr
+        ]
+        |> Fuzz.andThen
+            (\wrappedExpr ->
+                Fuzz.frequency
+                    [ ( 7, Fuzz.constant wrappedExpr )
+                    , ( 3, noOpWrap wrappedExpr ) -- recurse!
+                    ]
+            )
+
+
+literalExpressionFuzzer : Fuzzer (Node Expression)
+literalExpressionFuzzer =
+    withOptionalNoOps
+        (Fuzz.oneOf
+            [ rawIntExprFuzzer
+            , rawFloatExprFuzzer
+            , rawStringExprFuzzer
+            , rawCharExprFuzzer
+            , rawBoolExprFuzzer
+            ]
+        )
+
+
+charRange : Char -> Char -> Fuzzer Char
+charRange start end =
+    Fuzz.intRange (Char.toCode start) (Char.toCode end)
+        |> Fuzz.map Char.fromCode
+
+
+charFuzzer : Fuzzer Char
+charFuzzer =
+    Fuzz.oneOf
+        [ charRange 'a' 'z'
+        , charRange 'A' 'Z'
+        , charRange '0' '9'
+        ]
+
+
+removeNewlines : String -> String
+removeNewlines str =
+    str
+        |> String.toList
+        |> List.filter (\c -> c /= '\n' && c /= '\u{000D}')
+        |> String.fromList
+
+
+stringForPatternFuzzer : Fuzzer String
+stringForPatternFuzzer =
+    Fuzz.string |> Fuzz.map (String.slice 0 20 >> removeNewlines)
+
+
+simpleOperationFuzzer : Set String -> Int -> Fuzzer (Node Expression)
+simpleOperationFuzzer usedNames depth =
+    if depth <= 0 then
+        withOptionalNoOps literalExpressionFuzzer
+
+    else
+        withOptionalNoOps
+            (operatorFuzzer
+                |> Fuzz.andThen
+                    (\op ->
+                        case op of
+                            OrderingOp orderingOp ->
+                                orderingOperationFuzzer usedNames depth orderingOp
+
+                            EqualityOp equalityOp ->
+                                equalityOperationFuzzer usedNames depth equalityOp
+
+                            ArithmeticOp arithmeticOp ->
+                                arithmeticOperationFuzzer usedNames depth arithmeticOp
+
+                            BooleanOp booleanOp ->
+                                booleanOperationFuzzer usedNames depth booleanOp
+                    )
+            )
+
+
+orderingOperationFuzzer : Set String -> Int -> OrderingOperator -> Fuzzer (Node Expression)
+orderingOperationFuzzer usedNames depth op =
+    if depth <= 0 then
+        numberExpressionFuzzer
+
+    else
+        numberExpressionFuzzer
+            |> Fuzz.andThen
+                (\left ->
+                    Fuzz.map2
+                        (\dir right ->
+                            toNode
+                                (OperatorApplication (operatorToString (OrderingOp op))
+                                    dir
+                                    (parenthesize left)
+                                    (parenthesize right)
+                                )
+                        )
+                        infixDirectionFuzzer
+                        (Fuzz.lazy (\_ -> numberExpressionFuzzer))
+                )
+
+
+equalityOperationFuzzer : Set String -> Int -> EqualityOperator -> Fuzzer (Node Expression)
+equalityOperationFuzzer usedNames depth op =
+    if depth <= 0 then
+        literalExpressionFuzzer
+
+    else
+        exprTypeFuzzer
+            |> Fuzz.andThen
+                (\exprType ->
+                    Fuzz.map3
+                        (\dir left right ->
+                            toNode
+                                (OperatorApplication (operatorToString (EqualityOp op))
+                                    dir
+                                    (parenthesize left)
+                                    (parenthesize right)
+                                )
+                        )
+                        infixDirectionFuzzer
+                        (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                        (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                )
+
+
+arithmeticOperationFuzzer : Set String -> Int -> ArithmeticOperator -> Fuzzer (Node Expression)
+arithmeticOperationFuzzer usedNames depth op =
+    if depth <= 0 then
+        if op == IntDivide then
+            rawIntExprFuzzer
+
+        else
+            numberExpressionFuzzer
+
+    else
+        let
+            operandFuzzer =
+                if op == IntDivide then
+                    rawIntExprFuzzer
+
+                else
+                    numberExpressionFuzzer
+        in
+        Fuzz.map3
+            (\dir left right ->
+                toNode
+                    (OperatorApplication (operatorToString (ArithmeticOp op))
+                        dir
+                        (parenthesize left)
+                        (parenthesize right)
+                    )
+            )
+            infixDirectionFuzzer
+            (Fuzz.lazy (\_ -> operandFuzzer))
+            (Fuzz.lazy (\_ -> operandFuzzer))
+
+
+booleanOperationFuzzer : Set String -> Int -> BooleanOperator -> Fuzzer (Node Expression)
+booleanOperationFuzzer usedNames depth op =
+    if depth <= 0 then
+        rawBoolExprFuzzer
+
+    else
+        Fuzz.map3
+            (\dir left right ->
+                toNode
+                    (OperatorApplication (operatorToString (BooleanOp op))
+                        dir
+                        (parenthesize left)
+                        (parenthesize right)
+                    )
+            )
+            infixDirectionFuzzer
+            (Fuzz.lazy (\_ -> boolExpressionFuzzer usedNames (depth - 1)))
+            (Fuzz.lazy (\_ -> boolExpressionFuzzer usedNames (depth - 1)))
+
+
+numberExpressionFuzzer : Fuzzer (Node Expression)
+numberExpressionFuzzer =
+    Fuzz.oneOf
+        [ rawIntExprFuzzer
+        , rawFloatExprFuzzer
+        ]
+
+
+infixDirectionFuzzer : Fuzzer InfixDirection
+infixDirectionFuzzer =
+    Fuzz.oneOfValues
+        [ Left
+        , Right
+        , Non
+        ]
+
+
+type Operator
+    = OrderingOp OrderingOperator
+    | EqualityOp EqualityOperator
+    | ArithmeticOp ArithmeticOperator
+    | BooleanOp BooleanOperator
+
+
+type OrderingOperator
+    = LessThan
+    | LessThanOrEqual
+    | GreaterThan
+    | GreaterThanOrEqual
+
+
+type EqualityOperator
+    = Equal
+    | NotEqual
+
+
+type ArithmeticOperator
+    = Plus
+    | Minus
+    | Multiply
+    | IntDivide
+
+
+type BooleanOperator
+    = Or
+    | And
+
+
+operatorToString : Operator -> String
+operatorToString op =
+    case op of
+        OrderingOp LessThan ->
+            "<"
+
+        OrderingOp LessThanOrEqual ->
+            "<="
+
+        OrderingOp GreaterThan ->
+            ">"
+
+        OrderingOp GreaterThanOrEqual ->
+            ">="
+
+        EqualityOp Equal ->
+            "=="
+
+        EqualityOp NotEqual ->
+            "/="
+
+        ArithmeticOp Plus ->
+            "+"
+
+        ArithmeticOp Minus ->
+            "-"
+
+        ArithmeticOp Multiply ->
+            "*"
+
+        ArithmeticOp IntDivide ->
+            "//"
+
+        BooleanOp Or ->
+            "||"
+
+        BooleanOp And ->
+            "&&"
+
+
+operatorFuzzer : Fuzzer Operator
+operatorFuzzer =
+    Fuzz.oneOf
+        [ orderingOperatorFuzzer |> Fuzz.map OrderingOp
+        , equalityOperatorFuzzer |> Fuzz.map EqualityOp
+        , arithmeticOperatorFuzzer |> Fuzz.map ArithmeticOp
+        , booleanOperatorFuzzer |> Fuzz.map BooleanOp
+        ]
+
+
+orderingOperatorFuzzer : Fuzzer OrderingOperator
+orderingOperatorFuzzer =
+    Fuzz.oneOfValues
+        [ LessThan
+        , LessThanOrEqual
+        , GreaterThan
+        , GreaterThanOrEqual
+        ]
+
+
+equalityOperatorFuzzer : Fuzzer EqualityOperator
+equalityOperatorFuzzer =
+    Fuzz.oneOfValues
+        [ Equal
+        , NotEqual
+        ]
+
+
+arithmeticOperatorFuzzer : Fuzzer ArithmeticOperator
+arithmeticOperatorFuzzer =
+    Fuzz.oneOfValues
+        [ Plus
+        , Minus
+        , Multiply
+        , IntDivide
+        ]
+
+
+booleanOperatorFuzzer : Fuzzer BooleanOperator
+booleanOperatorFuzzer =
+    Fuzz.oneOfValues
+        [ Or
+        , And
+        ]
+
+
+unitExpressionFuzzer : Fuzzer (Node Expression)
+unitExpressionFuzzer =
+    withOptionalNoOps (Fuzz.constant (toNode UnitExpr))
+
+
+listExpressionFuzzer : Set String -> Int -> Fuzzer (Node Expression)
+listExpressionFuzzer usedNames depth =
+    if depth <= 0 then
+        withOptionalNoOps literalExpressionFuzzer
+
+    else
+        withOptionalNoOps
+            (exprTypeFuzzer
+                |> Fuzz.andThen
+                    (\exprType ->
+                        Fuzz.list (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                            |> Fuzz.map (\exprs -> toNode (ListExpr exprs))
+                    )
+            )
+
+
+tupleExpressionFuzzer : Set String -> Int -> Fuzzer (Node Expression)
+tupleExpressionFuzzer usedNames depth =
+    if depth <= 0 then
+        withOptionalNoOps literalExpressionFuzzer
+
+    else
+        withOptionalNoOps
+            (Fuzz.map2
+                (\left right ->
+                    toNode (TupledExpression [ left, right ])
+                )
+                (Fuzz.lazy (\_ -> expressionFuzzer usedNames (depth - 1)))
+                (Fuzz.lazy (\_ -> expressionFuzzer usedNames (depth - 1)))
+            )
+
+
+boolExpressionFuzzer : Set String -> Int -> Fuzzer (Node Expression)
+boolExpressionFuzzer usedNames depth =
+    if depth <= 0 then
+        -- Base case: only literal booleans
+        rawBoolExprFuzzer
+
+    else
+        Fuzz.frequency
+            [ -- Literal booleans (low weight)
+              ( 1
+              , rawBoolExprFuzzer
+              )
+            , -- Boolean operations: || and && (higher weight for nesting)
+              ( 3
+              , Fuzz.map2
+                    (\left right ->
+                        toNode (OperatorApplication "||" Left (parenthesize left) (parenthesize right))
+                    )
+                    (Fuzz.lazy (\_ -> boolExpressionFuzzer usedNames (depth - 1)))
+                    (Fuzz.lazy (\_ -> boolExpressionFuzzer usedNames (depth - 1)))
+              )
+            , ( 3
+              , Fuzz.map2
+                    (\left right ->
+                        toNode (OperatorApplication "&&" Left (parenthesize left) (parenthesize right))
+                    )
+                    (Fuzz.lazy (\_ -> boolExpressionFuzzer usedNames (depth - 1)))
+                    (Fuzz.lazy (\_ -> boolExpressionFuzzer usedNames (depth - 1)))
+              )
+            , -- Comparisons: == and /= for same-type (non-function) expressions (medium weight)
+              ( 2
+              , Fuzz.andThen
+                    (\exprType ->
+                        Fuzz.map2
+                            (\left right ->
+                                toNode (OperatorApplication "==" Non (parenthesize left) (parenthesize right))
+                            )
+                            (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                            (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                    )
+                    exprTypeFuzzer
+              )
+            , ( 2
+              , Fuzz.andThen
+                    (\exprType ->
+                        Fuzz.map2
+                            (\left right ->
+                                toNode (OperatorApplication "/=" Non (parenthesize left) (parenthesize right))
+                            )
+                            (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                            (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                    )
+                    exprTypeFuzzer
+              )
+            ]
+
+
+conditionFuzzer : Set String -> Int -> Fuzzer (Node Expression)
+conditionFuzzer usedNames depth =
+    boolExpressionFuzzer usedNames depth
+
+
+ifExpressionFuzzer : Set String -> Int -> Fuzzer (Node Expression)
+ifExpressionFuzzer usedNames depth =
+    if depth <= 0 then
+        withOptionalNoOps literalExpressionFuzzer
+
+    else
+        withOptionalNoOps
+            (exprTypeFuzzer
+                |> Fuzz.andThen
+                    (\exprType ->
+                        Fuzz.map3
+                            (\condition thenBranch elseBranch ->
+                                toNode (IfBlock condition thenBranch elseBranch)
+                            )
+                            (Fuzz.lazy (\_ -> conditionFuzzer usedNames (depth - 1)))
+                            (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                            (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                    )
+            )
+
+
+patternVarNameFuzzer : Set String -> Fuzzer String
+patternVarNameFuzzer usedNames =
+    let
+        availableNames =
+            [ "a", "b", "c", "y", "z" ]
+                |> List.filter (\name -> not (Set.member name usedNames))
+    in
+    if List.isEmpty availableNames then
+        -- Fallback: generate a unique name by appending numbers
+        Fuzz.intRange 0 9999 |> Fuzz.map (\n -> "var" ++ String.fromInt n)
+
+    else
+        Fuzz.oneOfValues availableNames
+
+
+intPatternFuzzer : Fuzzer (Node Pattern)
+intPatternFuzzer =
+    Fuzz.intRange 0 100 |> Fuzz.map (\i -> toNode (IntPattern i))
+
+
+stringPatternFuzzer : Fuzzer (Node Pattern)
+stringPatternFuzzer =
+    stringForPatternFuzzer |> Fuzz.map (\s -> toNode (StringPattern s))
+
+
+charPatternFuzzer : Fuzzer (Node Pattern)
+charPatternFuzzer =
+    charFuzzer |> Fuzz.map (\c -> toNode (CharPattern c))
+
+
+varPatternFuzzer : Set String -> Fuzzer (Node Pattern)
+varPatternFuzzer usedNames =
+    patternVarNameFuzzer usedNames |> Fuzz.map (\name -> toNode (VarPattern name))
+
+
+patternFuzzer : Set String -> Fuzzer (Node Pattern)
+patternFuzzer usedNames =
+    Fuzz.oneOf
+        [ varPatternFuzzer usedNames
+        , intPatternFuzzer -- don't use negative ints as patterns
+
+        -- don't use floats as patterns
+        , stringPatternFuzzer
+        , charPatternFuzzer
+        , Fuzz.bool |> Fuzz.map (\b -> toNode (VarPattern (boolToString b)))
+        , Fuzz.constant (toNode UnitPattern)
+        ]
+
+
+nonVarPatternOfTypeFuzzer : ExprType -> Fuzzer (Node Pattern)
+nonVarPatternOfTypeFuzzer subjectType =
+    case subjectType of
+        TInt ->
+            intPatternFuzzer
+
+        TFloat ->
+            -- Floats should not be used as case expression subjects
+            Fuzz.invalid "Floats should not be used as case expression subjects"
+
+        TString ->
+            stringPatternFuzzer
+
+        TChar ->
+            charPatternFuzzer
+
+        TBool ->
+            Fuzz.oneOfValues
+                [ toNode (VarPattern "True")
+                , toNode (VarPattern "False")
+                ]
+
+        TUnit ->
+            Fuzz.constant (toNode UnitPattern)
+
+
+patternFuzzerOfType : Set String -> ExprType -> Fuzzer (Node Pattern)
+patternFuzzerOfType usedNames subjectType =
+    case subjectType of
+        TInt ->
+            Fuzz.oneOf
+                [ intPatternFuzzer
+                , varPatternFuzzer usedNames
+                ]
+
+        TFloat ->
+            varPatternFuzzer usedNames
+
+        TString ->
+            Fuzz.oneOf
+                [ stringPatternFuzzer
+                , varPatternFuzzer usedNames
+                ]
+
+        TChar ->
+            Fuzz.oneOf
+                [ charPatternFuzzer
+                , varPatternFuzzer usedNames
+                ]
+
+        TBool ->
+            Fuzz.oneOf
+                [ Fuzz.constant (toNode (VarPattern "True"))
+                , Fuzz.constant (toNode (VarPattern "False"))
+                , varPatternFuzzer usedNames
+                ]
+
+        TUnit ->
+            Fuzz.constant (toNode UnitPattern)
+
+
+isVarPattern : Pattern -> Bool
+isVarPattern pattern =
+    case pattern of
+        VarPattern _ ->
+            True
+
+        _ ->
+            False
+
+
+caseExpressionFuzzer : Set String -> Int -> Fuzzer (Node Expression)
+caseExpressionFuzzer usedNames depth =
+    if depth <= 0 then
+        withOptionalNoOps literalExpressionFuzzer
+
+    else
+        withOptionalNoOps
+            (Fuzz.map2
+                (\subjectType exprType ->
+                    if subjectType == TUnit then
+                        -- Unit type only has one value (), so we must have exactly one case with UnitPattern
+                        Fuzz.map2
+                            (\caseExpr expr ->
+                                Fuzz.constant
+                                    (toNode
+                                        (CaseExpression
+                                            { expression = caseExpr
+                                            , cases = [ ( toNode UnitPattern, expr ) ]
+                                            }
+                                        )
+                                    )
+                            )
+                            (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) subjectType))
+                            (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+
+                    else if subjectType == TBool then
+                        -- For boolean subjects, use Fuzz.oneOf to choose one of the four valid patterns:
+                        -- 1. Just a var pattern
+                        -- 2. True pattern and var pattern
+                        -- 3. False pattern and var pattern
+                        -- 4. True pattern and False pattern
+                        Fuzz.map2
+                            (\caseExpr cases ->
+                                Fuzz.constant <|
+                                    toNode
+                                        (CaseExpression
+                                            { expression = caseExpr
+                                            , cases = cases
+                                            }
+                                        )
+                            )
+                            (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) subjectType))
+                            (Fuzz.oneOf
+                                [ -- 1. Just a var pattern
+                                  patternVarNameFuzzer usedNames
+                                    |> Fuzz.andThen
+                                        (\varName ->
+                                            expressionFuzzerOfType (Set.insert varName usedNames) (depth - 1) exprType
+                                                |> Fuzz.map
+                                                    (\expr ->
+                                                        [ ( toNode (VarPattern varName), expr ) ]
+                                                    )
+                                        )
+                                , -- 2. True pattern and var pattern
+                                  Fuzz.map2
+                                    (\trueExpr varCase ->
+                                        [ ( toNode (VarPattern "True"), trueExpr ), varCase ]
+                                    )
+                                    (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                                    (patternVarNameFuzzer usedNames
+                                        |> Fuzz.andThen
+                                            (\varName ->
+                                                expressionFuzzerOfType (Set.insert varName usedNames) (depth - 1) exprType
+                                                    |> Fuzz.map
+                                                        (\expr ->
+                                                            ( toNode (VarPattern varName), expr )
+                                                        )
+                                            )
+                                    )
+                                , -- 3. False pattern and var pattern
+                                  Fuzz.map2
+                                    (\falseExpr varCase ->
+                                        [ ( toNode (VarPattern "False"), falseExpr ), varCase ]
+                                    )
+                                    (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                                    (patternVarNameFuzzer usedNames
+                                        |> Fuzz.andThen
+                                            (\varName ->
+                                                expressionFuzzerOfType (Set.insert varName usedNames) (depth - 1) exprType
+                                                    |> Fuzz.map
+                                                        (\expr ->
+                                                            ( toNode (VarPattern varName), expr )
+                                                        )
+                                            )
+                                    )
+                                , -- 4. True pattern and False pattern
+                                  Fuzz.map2
+                                    (\trueExpr falseExpr ->
+                                        [ ( toNode (VarPattern "True"), trueExpr )
+                                        , ( toNode (VarPattern "False"), falseExpr )
+                                        ]
+                                    )
+                                    (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                                    (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                                ]
+                            )
+
+                    else
+                        Fuzz.map2
+                            (\caseExpr nonVarCases ->
+                                Fuzz.andThen
+                                    (\maybeVarCase ->
+                                        let
+                                            allCases =
+                                                case maybeVarCase of
+                                                    Just varCase ->
+                                                        nonVarCases ++ [ varCase ]
+
+                                                    Nothing ->
+                                                        nonVarCases
+
+                                            deduplicatedCases =
+                                                allCases
+                                                    |> ListExtra.uniqueBy (\( pattern, _ ) -> Elm.Syntax.Node.value pattern)
+                                        in
+                                        if List.isEmpty deduplicatedCases then
+                                            patternVarNameFuzzer usedNames
+                                                |> Fuzz.andThen
+                                                    (\varName ->
+                                                        expressionFuzzerOfType (Set.insert varName usedNames) (depth - 1) exprType
+                                                            |> Fuzz.map
+                                                                (\expr ->
+                                                                    toNode
+                                                                        (CaseExpression
+                                                                            { expression = caseExpr
+                                                                            , cases = [ ( toNode (VarPattern varName), expr ) ]
+                                                                            }
+                                                                        )
+                                                                )
+                                                    )
+
+                                        else
+                                            Fuzz.constant
+                                                (toNode
+                                                    (CaseExpression
+                                                        { expression = caseExpr
+                                                        , cases = deduplicatedCases
+                                                        }
+                                                    )
+                                                )
+                                    )
+                                    (if subjectType == TInt || subjectType == TFloat || subjectType == TString || subjectType == TChar then
+                                        -- These types as subjects must have a var pattern at the end (they're infinite)
+                                        Fuzz.map Just
+                                            (patternVarNameFuzzer usedNames
+                                                |> Fuzz.andThen
+                                                    (\varName ->
+                                                        Fuzz.map
+                                                            (\expr ->
+                                                                ( toNode (VarPattern varName)
+                                                                , expr
+                                                                )
+                                                            )
+                                                            (expressionFuzzerOfType (Set.insert varName usedNames) (depth - 1) exprType)
+                                                    )
+                                            )
+
+                                     else
+                                     -- For other types, ensure we have at least one pattern
+                                     if
+                                        List.isEmpty nonVarCases
+                                     then
+                                        -- If no non-var cases, we must generate at least one pattern (var pattern)
+                                        Fuzz.map Just
+                                            (patternVarNameFuzzer usedNames
+                                                |> Fuzz.andThen
+                                                    (\varName ->
+                                                        Fuzz.map
+                                                            (\expr ->
+                                                                ( toNode (VarPattern varName)
+                                                                , expr
+                                                                )
+                                                            )
+                                                            (expressionFuzzerOfType (Set.insert varName usedNames) (depth - 1) exprType)
+                                                    )
+                                            )
+
+                                     else
+                                        -- Optionally add a var pattern to the non-empty list of patterns.
+                                        Fuzz.maybe
+                                            (patternVarNameFuzzer usedNames
+                                                |> Fuzz.andThen
+                                                    (\varName ->
+                                                        Fuzz.map
+                                                            (\expr ->
+                                                                ( toNode (VarPattern varName)
+                                                                , expr
+                                                                )
+                                                            )
+                                                            (expressionFuzzerOfType (Set.insert varName usedNames) (depth - 1) exprType)
+                                                    )
+                                            )
+                                    )
+                            )
+                            (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) subjectType))
+                            (Fuzz.list
+                                (Fuzz.map2
+                                    (\pattern expr ->
+                                        ( pattern, expr )
+                                    )
+                                    (Fuzz.lazy (\_ -> nonVarPatternOfTypeFuzzer subjectType))
+                                    (Fuzz.lazy (\_ -> expressionFuzzerOfType usedNames (depth - 1) exprType))
+                                )
+                            )
+                )
+                exprTypeFuzzerWithoutFloat
+                exprTypeFuzzer
+                |> Fuzz.andThen identity
+                |> Fuzz.andThen identity
+            )
+
+
+toNode : a -> Node a
+toNode value =
+    Node Elm.Syntax.Range.empty value
+
+
+parenthesize : Node Expression -> Node Expression
+parenthesize expr =
+    toNode (ParenthesizedExpression expr)


### PR DESCRIPTION
This draft PR up just to let you know this exist - feel free to tinker with it.

I think this setup could realistically also test against differences from elm-format and so on - arbitrary side effect and binary calling via the `patching-elm-compiler.js`.

I'm still trying to make the fuzzer do more interesting stuff to provoke some errors.

The fuzz test I have right now is "if it compiles, it should also compile after instrumenting with `let _ = () in ...`"